### PR TITLE
Update webhook.py

### DIFF
--- a/ExtendedAIModule/rhombus_services/webhook.py
+++ b/ExtendedAIModule/rhombus_services/webhook.py
@@ -121,7 +121,7 @@ def __run(api_client: rapi.ApiClient) -> None:
     tunnel_url = __start_ngrok()
 
     # Get the API.
-    api = rapi.IntegrationWebserviceApi(api_client)
+    api = rapi.IntegrationsWebserviceApi(api_client)
 
     # Make the request to Rhombus containing our webhook URL.
     body = rapi.IntegrationUpdateWebhookIntegrationWSRequest(


### PR DESCRIPTION
Line 124 has been updated to reflect the proper class name as per RhombusAPI/api/integrations_webservice_api.py - program will issue an error at runtime otherwise.

AttributeError: module 'RhombusAPI' has no attribute 'IntegrationWebserviceApi'